### PR TITLE
Fix-search-from-ADAL

### DIFF
--- a/server-side/services/adal.service.ts
+++ b/server-side/services/adal.service.ts
@@ -63,15 +63,17 @@ export class AdalService implements IApiService
 	{
 		try
 		{
-			if(body.UniqueFieldID && body.UniqueFieldList.length > 0) 
+			this.validateBodyParams(body);
+			if(body.UniqueFieldID && body.UniqueFieldList && body.UniqueFieldList.length > 0) 
 			{
-				const valuesString = body.UniqueFieldList.map(field => `'${field}'`).join(',');
-				if(body.Where?.length > 0)
-				{
-					body.Where = `${body.Where} AND ${body.UniqueFieldID} in (${valuesString})`;
+				if(body.UniqueFieldID === "Key"){
+					body.KeyList = body.UniqueFieldList;
+					delete body.UniqueFieldID;
+					delete body.UniqueFieldList;
 				}
 				else
 				{
+					const valuesString = body.UniqueFieldList.map(field => `'${field}'`).join(',');
 					body.Where = `${body.UniqueFieldID} in (${valuesString})`;
 				}
 			}
@@ -80,6 +82,22 @@ export class AdalService implements IApiService
 		catch(error)
 		{
 			throw new ErrorWithStatus(error);
+		}
+	}
+
+
+	private validateBodyParams(body: any) {
+		if (body.KeyList && body.UniqueFieldList) {
+
+			Helper.throwErrorWithLog(`'UniqueFieldList' is mutually exclusive with 'KeyList'`);
+		}
+		if (body.Where && body.UniqueFieldList) {
+
+			Helper.throwErrorWithLog(`'UniqueFieldList' is mutually exclusive with 'Where' clause`);
+		}
+		if (body.UniqueFieldList && !body.UniqueFieldID) {
+
+			Helper.throwErrorWithLog(`Missing 'UniqueFieldID' parameter`);
 		}
 	}
 

--- a/server-side/services/adal.service.ts
+++ b/server-side/services/adal.service.ts
@@ -91,6 +91,10 @@ export class AdalService implements IApiService
 
 			Helper.throwErrorWithLog(`'UniqueFieldList' is mutually exclusive with 'KeyList'`);
 		}
+		if (body.Where && body.KeyList) {
+
+			Helper.throwErrorWithLog(`'KeyList' is mutually exclusive with 'Where' clause`);
+		}
 		if (body.Where && body.UniqueFieldList) {
 
 			Helper.throwErrorWithLog(`'UniqueFieldList' is mutually exclusive with 'Where' clause`);
@@ -99,6 +103,7 @@ export class AdalService implements IApiService
 
 			Helper.throwErrorWithLog(`Missing 'UniqueFieldID' parameter`);
 		}
+
 	}
 
 	async batchUpsert(resourceName: string,objects: any[])

--- a/shared/src/helper.ts
+++ b/shared/src/helper.ts
@@ -49,4 +49,10 @@ export class Helper
 		// Return the params object
 		return params;
 	  }
+
+	static throwErrorWithLog(errorMessage: string): void {
+		console.error(errorMessage);
+		throw new Error(errorMessage);
+	}
+
 }


### PR DESCRIPTION
1.Add validation on the body params (mutually exclusive params and mandatory param
2.When searching by unique field 'key' need to send it in Key list to ADAL and not in the where clause